### PR TITLE
feat: auth 페이지 관련 input, button들 구현

### DIFF
--- a/src/components/auth/auth-button.css
+++ b/src/components/auth/auth-button.css
@@ -1,0 +1,33 @@
+:root {
+	--color: var(--color-white);
+	--background-color: var(--color-primary);
+	--invalid-color: var(--color-white);
+	--invalid-background-color: #aaa;
+	--border-radius: 4px; /* 6px로 변경 가능성 있음 */
+}
+
+.auth-button {
+	/* Box Model */
+	width: 100%;
+	height: 50px;
+	/* Layout & Flex */
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: calc(var(--spacing-2) - 1px);
+	/* Visual */
+	border: none;
+	border-radius: var(--border-radius);
+	background-color: var(--background-color);
+	color: var(--color);
+	/* Typography */
+	font-size: var(--font-size-sm);
+}
+
+form:has(input:invalid, textarea:invalid) .auth-button {
+	/* Miscellaneous */
+	cursor: not-allowed;
+	/* Visual */
+	color: var(--invalid-color);
+	background-color: var(--invalid-background-color);
+}

--- a/src/components/auth/auth-input-signup.css
+++ b/src/components/auth/auth-input-signup.css
@@ -1,0 +1,40 @@
+@import './auth-input.css';
+
+.auth-input.sign-up {
+	/* Layout & Flex */
+	display: flex;
+	align-items: center;
+
+	& > .auth-input-valid {
+		/* Box Model */
+		position: absolute;
+		top: calc(100% + var(--spacing-2));
+		display: none;
+		/* Typography */
+		font-size: 12px;
+		letter-spacing: var(--letter-spacing-tight);
+		/* Visual */
+		color: var(--color-primary);
+	}
+
+	& > input:valid + .auth-input-error + .auth-input-valid {
+		display: block;
+	}
+
+	& > .duplicate-check-button {
+		/* Box Model */
+		width: 65px;
+		height: 29px;
+		/* Visual */
+		background-color: transparent;
+		border: 1px solid currentColor;
+		border-radius: 14.5px;
+		color: var(--color-primary);
+		/* Typography */
+		font-size: var(--font-size-xs);
+	}
+
+	&:has(input:invalid) .duplicate-check-button {
+		color: var(--color-font-light-gray);
+	}
+}

--- a/src/components/auth/auth-input.css
+++ b/src/components/auth/auth-input.css
@@ -1,0 +1,41 @@
+.auth-input {
+	/* Box Model */
+	position: relative;
+	width: 100%;
+	height: 43px;
+	border-bottom: 1px solid #d7d7d7;
+
+	&:has(input:focus) {
+		border-bottom: 1px solid var(--color-primary);
+	}
+
+	& > input {
+		/* Box Model */
+		height: 100%;
+		border: none;
+		outline: none;
+		/* Typography */
+		font-size: 16px;
+		letter-spacing: var(--letter-spacing-tight);
+		&::placeholder {
+			/* Visual */
+			color: #8e8e8e;
+		}
+	}
+
+	& > .auth-input-error {
+		/* Box Model */
+		position: absolute;
+		top: calc(100% + var(--spacing-2));
+		display: none;
+		/* Typography */
+		font-size: 12px;
+		letter-spacing: var(--letter-spacing-tight);
+		/* Visual */
+		color: #fc3b75;
+	}
+
+	& > input:user-invalid + .auth-input-error {
+		display: block;
+	}
+}

--- a/src/components/auth/index.html
+++ b/src/components/auth/index.html
@@ -62,6 +62,14 @@
 				버튼 텍스트
 			</button>
 		</form>
+
+		<div style="height: 50px"></div>
+
+		<a href="#" class="auth-button">
+			<!-- 그냥 버튼 링크 -->
+			<!-- <img src="/img/google.svg" alt="Google" /> -->
+			버튼 텍스트
+		</a>
 	</head>
 	<body></body>
 </html>

--- a/src/components/auth/index.html
+++ b/src/components/auth/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="ko-KR">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>컴포넌트</title>
+		<link rel="icon" href="/vite.svg" />
+		<link
+			rel="preload"
+			as="font"
+			href="/font/woff2/PretendardVariable.woff2"
+			crossorigin="anonymous"
+		/>
+		<link rel="stylesheet" as="style" href="/font/pretendardvariable.css" />
+		<link rel="stylesheet" href="/src/global.css" />
+		<link rel="stylesheet" href="./style.css" />
+		<form action="" method="post">
+			<!-- input box -->
+			<div class="auth-input">
+				<!-- 여러 input을 사용할 경우 각각 다른(고유한) id, name을 사용해주세요 -->
+				<label for="auth-input" class="sr-only">레이블 이름</label>
+				<input
+					type="text"
+					id="auth-input"
+					name="auth-input"
+					class="auth-input"
+					placeholder="여기에 placeholder"
+					minlength="3"
+					maxlength="10"
+					required
+				/>
+				<span class="auth-input-error">에러 메시지</span>
+			</div>
+
+			<div style="height: 50px"></div>
+
+			<!-- input box 회원 가입 시 중복 확인 필요 -->
+			<div class="auth-input sign-up">
+				<!-- 여러 input을 사용할 경우 각각 다른(고유한) id, name을 사용해주세요 -->
+				<label for="auth-input" class="sr-only">레이블 이름</label>
+				<input
+					type="text"
+					id="auth-input"
+					name="auth-input"
+					class="auth-input"
+					placeholder="여기에 placeholder"
+					minlength="3"
+					maxlength="10"
+					required
+				/>
+				<span class="auth-input-error">에러 메시지</span>
+				<span class="auth-input-valid">사용 가능한~</span>
+				<button type="button" class="duplicate-check-button">중복확인</button>
+			</div>
+
+			<div style="height: 50px"></div>
+
+			<!-- 타입은 용도에 따라 사용 시 변경해주세요 -->
+			<button type="submit" class="auth-button">
+				<!-- 여기 선택적으로 아이콘 넣어주세요 -->
+				<!-- <img src="/img/google.svg" alt="Google" /> -->
+				버튼 텍스트
+			</button>
+		</form>
+	</head>
+	<body></body>
+</html>

--- a/src/components/auth/index.html
+++ b/src/components/auth/index.html
@@ -14,7 +14,9 @@
 		<link rel="stylesheet" as="style" href="/font/pretendardvariable.css" />
 		<link rel="stylesheet" href="/src/global.css" />
 		<link rel="stylesheet" href="./style.css" />
-		<form action="" method="post">
+	</head>
+	<body>
+		<form action="" method="POST">
 			<!-- input box -->
 			<div class="auth-input">
 				<!-- 여러 input을 사용할 경우 각각 다른(고유한) id, name을 사용해주세요 -->
@@ -70,6 +72,5 @@
 			<!-- <img src="/img/google.svg" alt="Google" /> -->
 			버튼 텍스트
 		</a>
-	</head>
-	<body></body>
+	</body>
 </html>

--- a/src/components/auth/style.css
+++ b/src/components/auth/style.css
@@ -1,0 +1,3 @@
+@import './auth-input.css';
+@import './auth-input-signup.css';
+@import './auth-button.css';


### PR DESCRIPTION
# Description

재사용 가능하도록 css만 별도로 분리하였으니 사용할 때 해당 html 요소를 가져와 속성값과 텍스트를 조작하고, 해당 css 파일만 import하시면 됩니다.

- auth-input: 에러 메시지
  - 첫 렌더링 때는 에러 메시지가 뜨진 않지만, 에러가 발생할 경우 에러 메시지가 등장합니다.
  - 이 때, 에러 메시지는 레이아웃에 영향을 주지 않아야 하기 때문에 `position: absolute`로 구현하였습니다. 
  ![스크린샷 2025-05-29 오후 4 39 18](https://github.com/user-attachments/assets/3f7c6e47-306c-4e25-a36d-3c8fe458614c)
- auth-input-signup: 에러 메시지, 유효 메시지, 중복 확인 버튼
  - auth-input에서 css를 가져왔습니다
  - 중복확인 버튼과 valid 메시지 요소를 추가하였고. valid 요소와 중복확인 버튼 관련 기능은 서버가 없기에 그냥 조건 만족 시 색만 변경되도록 하였습니다.
  - 비밀 번호로 사용 시에는 button을 제거하고 눈 이미지를 추가하면 될 것 같습니다.
  ![스크린샷 2025-05-29 오후 4 39 44](https://github.com/user-attachments/assets/5b6abca6-da06-4510-b545-dc8c7fd3d7c3)
- auth-button: 제출 혹은 링크
  - 색이 매우 다양하며, form이 유효한지 여부에 따라서도 색이 변경됩니다.
  - a 요소로 그냥 링크 형태로도 사용 가능하도록 요소만 변경하여 구분해두었습니다. 
  ![스크린샷 2025-05-29 오후 4 38 39](https://github.com/user-attachments/assets/3794d6cb-98fb-4ef4-a956-fe5316eb0046)

Resolve #17

## Type of change

여기서 변경 사항에 대해 자세히 작성해주시고 완료 유무를 체크 표시

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update
